### PR TITLE
New error creation methods

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018-2019 William Moreton
+Copyright (c) 2018-2020 William Moreton
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/emulator/compiletime/create.c
+++ b/src/emulator/compiletime/create.c
@@ -63,23 +63,6 @@ void addCommand(VMCoreGen* core, Command command) {
     PUSH_ARRAY(Command, *core, command, command);
 }
 
-char* aprintf(char* format, ...) {
-    va_list args;
-    va_start(args, format);
-
-    size_t len = vsnprintf(NULL, 0, format, args) + 1;
-    char* buf = ArenaAlloc(len * sizeof(char));
-
-    va_end(args);
-    va_start(args, format);
-
-    vsprintf(buf, format, args);
-
-    va_end(args);
-
-    return buf;
-}
-
 void addHeader(VMCoreGen* core, const char* header) {
     tableSet(&core->headers, (void*)header, (void*)1);
 }

--- a/src/microcode/analyse.c
+++ b/src/microcode/analyse.c
@@ -597,7 +597,7 @@ static void analyseOpcode(Parser* parser, ASTStatement* s, VMCoreGen* core) {
         GenOpCode* gencode = &core->opcodes[opcodeID+i];
         gencode->isValid = true;
         gencode->id = opcodeID+i;
-        gencode->name = opcode->name.range.start;
+        gencode->name = opcode->name.range.tokenStart;
         gencode->nameLen = opcode->name.range.length;
         ARRAY_ALLOC(GenOpCodeLine, *gencode, line);
 

--- a/src/microcode/analyse.h
+++ b/src/microcode/analyse.h
@@ -4,7 +4,6 @@
 struct Parser;
 struct VMCoreGen;
 
-void InitAnalysis();
 void Analyse(struct Parser* parser, struct VMCoreGen* core);
 
 #endif

--- a/src/microcode/error.c
+++ b/src/microcode/error.c
@@ -8,8 +8,7 @@
 #include "microcode/error.h"
 #include "shared/log.h"
 
-// TODO: properly implement errors at end of file
-
+/*
 static void printLine(Parser* parser, int line, int* start, int* length, int lineNumberLength) {
     if(getLine(parser->scanner->base, line, start, length)) {
         cErrPrintf(TextWhite, "  %*i | %.*s\n", lineNumberLength, line, *length, parser->scanner->base + *start);
@@ -17,7 +16,7 @@ static void printLine(Parser* parser, int line, int* start, int* length, int lin
 }
 
 // print a message about a token to stderr
-void printMessage(Parser* parser, SourceRange* range, const char* name, unsigned int code, TextColor color,
+static void printMessage(Parser* parser, SourceRange* range, const char* name, unsigned int code, TextColor color,
     const char* message) {
     CONTEXT(DEBUG, "Printing Error");
     setErrorState(parser);
@@ -70,141 +69,49 @@ void printMessage(Parser* parser, SourceRange* range, const char* name, unsigned
     printLine(parser, range->line + 1, &start, &length, lineNumberLength);
 
     printf("\n");
+}*/
+
+Error* errNew(ErrorLevel level) {
+    CONTEXT(INFO, "Creating Error");
+    Error* err = ArenaAlloc(sizeof(Error));
+    err->level = level;
 }
 
-typedef struct ErrorList {
-    DEFINE_ARRAY(Error*, error);
-} ErrorList;
-static ErrorList possibleErrors = {0};
-
-static void newErr(Error* error, ErrorLevel level, const char* message) {
-    CONTEXT(TRACE, "Creating new error definition");
-    if(possibleErrors.errors == NULL) {
-        ARRAY_ALLOC(Error*, possibleErrors, error);
-    }
-    PUSH_ARRAY(Error*, possibleErrors, error, error);
-
-    error->id = possibleErrors.errorCount;
-    error->level = level;
-    error->message = message;
-    TRACE("Allocating error note array");
-    ARRAY_ALLOC(const char*, *error, note);
-}
-
-void newErrAt(Error* error, ErrorLevel level, const char* message) {
-    newErr(error, level, message);
-    error->location = EL_ASK;
-}
-
-void newErrCurrent(Error* error, ErrorLevel level, const char* message) {
-    newErr(error, level, message);
-    error->location = EL_CURRENT;
-}
-
-void newErrPrevious(Error* error, ErrorLevel level, const char* message) {
-    newErr(error, level, message);
-    error->location = EL_PREVIOUS;
-}
-
-void newErrEnd(Error* error, ErrorLevel level, const char* message) {
-    newErr(error, level, message);
-    error->location = EL_END;
-}
-
-void newErrConsume(Error* error, ErrorLevel level,
-    MicrocodeTokenType type, const char* message) {
-
-    newErr(error, level, message);
-    error->consumeType = type;
-    error->location = EL_CURRENT;
-}
-
-void newErrNoteAt(Error* error, const char* message) {
-    PUSH_ARRAY(const char*, *error, note, message);
-}
-
-static char* getMessagePrint(const char* message, va_list args) {
-    va_list temp;
-
-    va_copy(temp, args);
-    size_t len = vsnprintf(NULL, 0, message, temp) + 1;
-    va_end(temp);
-
-    char* buf = ArenaAlloc(len * sizeof(char));
-    vsprintf(buf, message, args);
-
-    return buf;
-}
-
-void vError(Parser* parser, Error* error, va_list args) {
-    CONTEXT(INFO, "Emitting error");
-    if(parser->panicMode) return;
-    parser->hadError = true;
-
-    EmittedError eErr = {0};
-    eErr.atEnd = false;
-    eErr.parser = parser;
-    eErr.error = error;
-
-    switch(error->location) {
-        case EL_ASK:
-            eErr.range = *va_arg(args, SourceRange*);
-            break;
-        case EL_CURRENT:
-            eErr.range = parser->current.range;
-            break;
-        case EL_PREVIOUS:
-            eErr.range = parser->previous.range;
-            break;
-        case EL_END:
-            eErr.atEnd = true;
-            break;
-    }
-
-    switch(error->level) {
-        case ERROR_SEMANTIC:
-            eErr.name = "Semantic Error";
-            eErr.color = TextRed;
-            break;
-        case ERROR_SYNTAX:
-            eErr.name = "Syntax Error";
-            eErr.color = TextRed;
-            parser->panicMode = true;
-            break;
-    }
-
-    eErr.message = getMessagePrint(error->message, args);
-
-    if(error->noteCount > 0) {
-        ARRAY_ALLOC(EmittedErrorNoteData, eErr, noteData);
-    }
-
-    for(unsigned int i = 0; i < error->noteCount; i++) {
-        EmittedErrorNoteData data = {0};
-        data.token = *va_arg(args, SourceRange*);
-        data.message = getMessagePrint(error->notes[i], args);
-        PUSH_ARRAY(EmittedErrorNoteData, eErr, noteData, data);
-    }
-
-    PUSH_ARRAY(EmittedError, *parser, error, eErr);
-}
-
-void error(Parser* parser, Error* error, ...) {
+void errAddText(Error* err, TextColor color, const char* text, ...) {
     va_list args;
-    va_start(args, error);
-    vError(parser, error, args);
+    va_start(args, text);
+    vErrAddText(err, color, text, args);
     va_end(args);
 }
 
-void printErrors(Parser* parser) {
-    CONTEXT(DEBUG, "Printing all errors");
-    for(unsigned int i = 0; i < parser->errorCount; i++) {
-        EmittedError* err = &parser->errors[i];
-        printMessage(err->parser, &err->range, err->name, err->error->id, err->color, err->message);
+void vErrAddText(Error* err, TextColor color, const char* text, va_list args) {
+    CONTEXT(TRACE, "Adding text to error");
+    ErrorChunk chunk;
+    chunk.type = ERROR_CHUNK_TEXT;
+    chunk.as.text = vaprintf(text, args);
+    PUSH_ARRAY(ErrorChunk, *err, chunk, chunk);
+}
 
-        for(unsigned int j = 0; j < err->noteDataCount; j++) {
-            EmittedErrorNoteData* data = &err->noteDatas[j];
-            printMessage(err->parser, &data->token, "Note", 0, TextBlue, data->message);
-        }
+void errAddSource(Error* err, SourceRange* loc) {
+    CONTEXT(TRACE, "Adding source to error");
+    ErrorChunk chunk;
+    chunk.type = ERROR_CHUNK_SOURCE;
+    chunk.as.source = *loc;
+    PUSH_ARRAY(ErrorChunk, *err, chunk, chunk);
+}
+
+void errEmit(Error* err, struct Parser* parser) {
+    CONTEXT(INFO, "Emitting created error");
+    if(parser->panicMode) return;
+    parser->hadError = true;
+
+    if(err->level == ERROR_SYNTAX) {
+        parser->panicMode = true;
     }
+
+    PUSH_ARRAY(Error, *parser, error, err);
+}
+
+void printErrors(Parser* parser) {
+    printf("PRINTING ERROR - TODO: SHOW PROPER INFOMATION");
 }

--- a/src/microcode/error.c
+++ b/src/microcode/error.c
@@ -74,8 +74,11 @@ static void printMessage(Parser* parser, SourceRange* range, const char* name, u
 Error* errNew(ErrorLevel level) {
     CONTEXT(INFO, "Creating Error");
     Error* err = ArenaAlloc(sizeof(Error));
+
     err->level = level;
     ARRAY_ALLOC(ErrorChunk, *err, chunk);
+
+    return err;
 }
 
 void errAddText(Error* err, TextColor color, const char* text, ...) {
@@ -89,7 +92,8 @@ void vErrAddText(Error* err, TextColor color, const char* text, va_list args) {
     CONTEXT(TRACE, "Adding text to error");
     ErrorChunk chunk;
     chunk.type = ERROR_CHUNK_TEXT;
-    chunk.as.text = vaprintf(text, args);
+    chunk.as.text.message = vaprintf(text, args);
+    chunk.as.text.color = color;
     PUSH_ARRAY(ErrorChunk, *err, chunk, chunk);
 }
 
@@ -115,4 +119,5 @@ void errEmit(Error* err, struct Parser* parser) {
 
 void printErrors(Parser* parser) {
     printf("PRINTING ERROR - TODO: SHOW PROPER INFOMATION");
+    (void)parser;
 }

--- a/src/microcode/error.c
+++ b/src/microcode/error.c
@@ -75,6 +75,7 @@ Error* errNew(ErrorLevel level) {
     CONTEXT(INFO, "Creating Error");
     Error* err = ArenaAlloc(sizeof(Error));
     err->level = level;
+    ARRAY_ALLOC(ErrorChunk, *err, chunk);
 }
 
 void errAddText(Error* err, TextColor color, const char* text, ...) {

--- a/src/microcode/error.h
+++ b/src/microcode/error.h
@@ -17,7 +17,10 @@ typedef struct ErrorChunk {
     } type;
 
     union {
-        const char* text;
+        struct {
+            const char* message;
+            TextColor color;
+        } text;
         SourceRange source;
     } as;
 } ErrorChunk;

--- a/src/microcode/parser.c
+++ b/src/microcode/parser.c
@@ -47,7 +47,8 @@ static void advance(Parser* parser) {
 
         DEBUG("Found error token");
         Error* err = errNew(ERROR_SYNTAX);
-        errAddText(err, TextRed, "Unexpected Character %s", parser->current.data.string);
+        errAddText(err, TextRed, "Unexpected Character %s",
+            parser->current.data.string);
         errAddSource(err, &parser->current.range);
         errEmit(err, parser);
     }
@@ -107,25 +108,6 @@ static void syncronise(Parser* parser) {
     INFO("Could not detect valid parser state");
 }
 
-static Error errParameterRightParen = {0};
-static Error errConditionValue = {0};
-static Error errConditionValueRepeated = {0};
-static Error errConditionColon = {0};
-static Error errConditionSemicolon = {0};
-static Error errNoSecondConditionLine = {0};
-static void microcodeLineErrors() {
-    newErrConsume(&errParameterRightParen, ERROR_SYNTAX,
-        TOKEN_RIGHT_PAREN, "Expected )");
-    newErrPrevious(&errConditionValue, ERROR_SEMANTIC, "Condition values can only be 0 or 1");
-    newErrPrevious(&errConditionValueRepeated, ERROR_SEMANTIC, "Condition value %u repeated");
-    newErrConsume(&errConditionColon, ERROR_SYNTAX,
-        TOKEN_COLON, "Expected colon after condition");
-    newErrConsume(&errConditionSemicolon, ERROR_SYNTAX,
-        TOKEN_SEMICOLON, "Semicolon expected between parts of conditional microcode line");
-    newErrConsume(&errNoSecondConditionLine, ERROR_SYNTAX,
-        TOKEN_NUMBER, "Expected second condition value");
-}
-
 static BitArray parseMicrocodeBitArray(Parser* parser) {
     CONTEXT(INFO, "Parsing microcode bit array");
     BitArray result;
@@ -151,13 +133,15 @@ static BitArray parseMicrocodeBitArray(Parser* parser) {
             consume(parser, TOKEN_RIGHT_PAREN, "Expected ')', got '%s'",
                 parser->previous.data.string);
         }
-        bit.range.length = parser->previous.range.start + parser->previous.range.length - bit.range.start;
+        bit.range.length = parser->previous.range.start +
+            parser->previous.range.length - bit.range.start;
         PUSH_ARRAY(Token, result, data, bit);
         if(!match(parser, TOKEN_COMMA)) {
             break;
         }
     }
-    result.range.length = parser->previous.range.start + parser->previous.range.length - result.range.start;
+    result.range.length = parser->previous.range.start +
+        parser->previous.range.length - result.range.start;
     return result;
 }
 
@@ -179,24 +163,37 @@ static Line* microcodeLine(Parser* parser) {
             INFO("Microcode line has swapped condition values");
             swap = true;
         } else {
-            error(parser, &errConditionValue);
+            Error* err = errNew(ERROR_SYNTAX);
+            errAddText(err, TextRed, "Condition values can only be 0 or 1");
+            errAddSource(err, &parser->previous.range);
+            errEmit(err, parser);
         }
-        consume(parser, &errConditionColon);
+        consume(parser, TOKEN_COLON, "Expected colon after condition");
         line->bitsHigh = parseMicrocodeBitArray(parser);
-        consume(parser, &errConditionSemicolon);
-        consume(parser, &errNoSecondConditionLine);
+        consume(parser, TOKEN_SEMICOLON,
+            "Semicolon expected between parts of conditional microcode line");
+        consume(parser, TOKEN_NUMBER, "Expected second condition value");
         if(parser->previous.data.value == 1) {
             if(!swap) {
-                error(parser, &errConditionValueRepeated, 1);
+                Error* err = errNew(ERROR_SEMANTIC);
+                errAddText(err, TextRed, "Condition value 1 repeated");
+                errAddSource(err, &parser->previous.range);
+                errEmit(err, parser);
             }
         } else if(parser->previous.data.value == 0) {
             if(swap) {
-                error(parser, &errConditionValueRepeated, 0);
+                Error* err = errNew(ERROR_SEMANTIC);
+                errAddText(err, TextRed, "Condition value 0 repeated");
+                errAddSource(err, &parser->previous.range);
+                errEmit(err, parser);
             }
         } else {
-            error(parser, &errConditionValue);
+            Error* err = errNew(ERROR_SYNTAX);
+            errAddText(err, TextRed, "Condition values can only be 0 or 1");
+            errAddSource(err, &parser->previous.range);
+            errEmit(err, parser);
         }
-        consume(parser, &errConditionColon);
+        consume(parser, TOKEN_COLON, "Expected colon after condition");
         line->bitsLow = parseMicrocodeBitArray(parser);
 
         if(swap) {
@@ -213,35 +210,17 @@ static Line* microcodeLine(Parser* parser) {
     return line;
 }
 
-static Error errEnumSizeOpen = {0};
-static Error errEnumSizeNumber = {0};
-static Error errEnumSizeClose = {0};
-static Error errBlockStart = {0};
-static Error errBlockEnd = {0};
-static void typeEnumErrors() {
-    newErrConsume(&errEnumSizeOpen, ERROR_SYNTAX,
-        TOKEN_LEFT_PAREN, "Expected \"(\" before width of enum");
-    newErrConsume(&errEnumSizeNumber, ERROR_SYNTAX,
-        TOKEN_NUMBER, "Expected enum width to be a number");
-    newErrConsume(&errEnumSizeClose, ERROR_SYNTAX,
-        TOKEN_RIGHT_PAREN, "Expected \")\" after enum width");
-    newErrConsume(&errBlockStart, ERROR_SYNTAX,
-        TOKEN_LEFT_BRACE, "Expected \"{\" at start of block");
-    newErrConsume(&errBlockEnd, ERROR_SYNTAX,
-        TOKEN_RIGHT_BRACE, "Expected \"}\" at end of block");
-}
-
 static void typeEnum(Parser* parser, ASTStatement* s) {
     CONTEXT(INFO, "Parsing enum type expression");
 
     s->as.type.type = USER_TYPE_ENUM;
 
-    consume(parser, &errEnumSizeOpen);
-    consume(parser, &errEnumSizeNumber);
+    consume(parser, TOKEN_LEFT_PAREN, "Expected \"(\" before width of enum");
+    consume(parser, TOKEN_NUMBER, "Expected enum width to be a number");
     s->as.type.as.enumType.width = parser->previous;
 
-    consume(parser, &errEnumSizeClose);
-    consume(parser, &errBlockStart);
+    consume(parser, TOKEN_RIGHT_PAREN, "Expected \")\" after enum width");
+    consume(parser, TOKEN_LEFT_BRACE, "Expected \"{\" at start of block");
 
     ARRAY_ALLOC(Token, s->as.type.as.enumType, member);
     while(match(parser, TOKEN_IDENTIFIER)) {
@@ -251,19 +230,7 @@ static void typeEnum(Parser* parser, ASTStatement* s) {
         }
     }
 
-    consume(parser, &errBlockEnd);
-}
-
-static Error errMissingTypeName = {0};
-static Error errMissingTypeEquals = {0};
-static Error errTypeTypeWrong = {0};
-static void typeErrors() {
-    newErrConsume(&errMissingTypeName, ERROR_SYNTAX,
-        TOKEN_IDENTIFIER, "Expected name of type being parsed");
-    newErrConsume(&errMissingTypeEquals, ERROR_SYNTAX,
-        TOKEN_EQUAL, "Expected \"=\" to assign value in type declaration");
-    newErrPrevious(&errTypeTypeWrong, ERROR_SYNTAX,
-        "Expected type name (e.g. \"enum\"), got %s");
+    consume(parser, TOKEN_RIGHT_BRACE, "Expected \"}\" at end of block");
 }
 
 static void type(Parser* parser) {
@@ -272,28 +239,24 @@ static void type(Parser* parser) {
 
     ASTStatement* s = newStatement(parser, AST_BLOCK_TYPE);
 
-    consume(parser, &errMissingTypeName);
+    consume(parser, TOKEN_IDENTIFIER, "Expected name of type being parsed");
     s->as.type.name = parser->previous;
 
-    consume(parser, &errMissingTypeEquals);
+    consume(parser, TOKEN_EQUAL,
+        "Expected \"=\" to assign value in type declaration");
 
     advance(parser);
     switch(parser->previous.type) {
         case TOKEN_ENUM: typeEnum(parser, s); break;
-        default:
-            error(parser, &errTypeTypeWrong, TokenNames[parser->previous.type]);
+        default: {
+            Error* err = errNew(ERROR_SYNTAX);
+            errAddText(err, TextRed, "Expected type name, got %s");
+            errAddSource(err, &parser->previous.range);
+            errEmit(err, parser);
+        }
     }
 
     s->isValid = !endErrorState(parser);
-}
-
-static Error errParameterColon = {0};
-static Error errParameterNumber = {0};
-static void parameterErrors() {
-    newErrConsume(&errParameterColon, ERROR_SYNTAX,
-        TOKEN_COLON, "Missing colon seperating property %s from its value");
-    newErrConsume(&errParameterNumber, ERROR_SYNTAX,
-        TOKEN_NUMBER, "Missing value of %s parameter");
 }
 
 static void parameter(Parser* parser) {
@@ -304,16 +267,14 @@ static void parameter(Parser* parser) {
     Token* name = &parser->previous;
     s->as.parameter.name = *name;
 
-    consume(parser, &errParameterColon, name->data.string);
-    consume(parser, &errParameterNumber, name->data.string);
+    consume(parser, TOKEN_COLON,
+        "Missing colon seperating property %s from its value",
+        name->data.string);
+    consume(parser, TOKEN_NUMBER, "Missing value of %s parameter",
+        name->data.string);
     s->as.parameter.value = parser->previous;
 
     s->isValid = !endErrorState(parser);
-}
-
-static Error errHeaderCondition = {0};
-static void headerErrors() {
-    newErrAt(&errHeaderCondition, ERROR_SEMANTIC, "Condition values not allowed in header");
 }
 
 // parses a header statement
@@ -325,7 +286,7 @@ static void header(Parser* parser) {
     ARRAY_ALLOC(BitArray, s->as.header, line);
     s->as.header.errorPoint = parser->previous;
 
-    consume(parser, &errBlockStart);
+    consume(parser, TOKEN_LEFT_BRACE, "Expected \"{\" at start of block");
 
     while(!check(parser, TOKEN_EOF)) {
         if(check(parser, TOKEN_RIGHT_BRACE)) {
@@ -335,7 +296,10 @@ static void header(Parser* parser) {
 
         if(line->hasCondition) {
             INFO("Found condition in header statement");
-            error(parser, &errHeaderCondition, &line->conditionErrorToken.range);
+            Error* err = errNew(ERROR_SEMANTIC);
+            errAddText(err, TextRed, "Condition values not allowed in header");
+            errAddSource(err, &line->conditionErrorToken.range);
+            errEmit(err, parser);
         }
 
         PUSH_ARRAY(BitArray, s->as.header, line, line->bitsLow);
@@ -344,27 +308,9 @@ static void header(Parser* parser) {
         }
     }
 
-    consume(parser, &errBlockEnd);
+    consume(parser, TOKEN_RIGHT_BRACE, "Expected \"}\" at end of block");
 
     s->isValid = !endErrorState(parser);
-}
-
-static Error errOpcodeID = {0};
-static Error errOpcodeName = {0};
-static Error errOpcodeParamStart = {0};
-static Error errOpcodeParamEnd = {0};
-static Error errMissingTypeParameterName = {0};
-static void opcodeErrors() {
-    newErrConsume(&errOpcodeID, ERROR_SYNTAX,
-        TOKEN_BINARY, "Expected opcode number, got %s");
-    newErrConsume(&errOpcodeName, ERROR_SYNTAX,
-        TOKEN_IDENTIFIER, "Expected opcode name, got %s");
-    newErrConsume(&errOpcodeParamStart, ERROR_SYNTAX,
-        TOKEN_LEFT_PAREN, "Expected left paren, got %s");
-    newErrConsume(&errOpcodeParamEnd, ERROR_SYNTAX,
-        TOKEN_RIGHT_PAREN, "Expected right paren, got %s");
-    newErrConsume(&errMissingTypeParameterName, ERROR_SYNTAX,
-        TOKEN_IDENTIFIER, "Expecting the name of a parameter after its type");
 }
 
 static void opcode(Parser* parser) {
@@ -374,18 +320,22 @@ static void opcode(Parser* parser) {
     ASTStatement* s = newStatement(parser, AST_BLOCK_OPCODE);
     ARRAY_ALLOC(Line*, s->as.opcode, line);
 
-    consume(parser, &errOpcodeName, TokenNames[parser->current.type]);
+    consume(parser, TOKEN_IDENTIFIER, "Expected opcode name, got %s",
+        TokenNames[parser->current.type]);
     s->as.opcode.name = parser->previous;
-    consume(parser, &errOpcodeID, TokenNames[parser->current.type]);
+    consume(parser, TOKEN_BINARY, "Expected opcode number, got %s",
+        TokenNames[parser->current.type]);
     s->as.opcode.id = parser->previous;
 
     ARRAY_ALLOC(ASTParameter, s->as.opcode, param);
-    consume(parser, &errOpcodeParamStart, TokenNames[parser->current.type]);
+    consume(parser, TOKEN_LEFT_PAREN, "Expected left paren, got %s",
+        TokenNames[parser->current.type]);
     while(match(parser, TOKEN_IDENTIFIER)) {
         ASTParameter param = {0};
         param.name = parser->previous;
 
-        consume(parser, &errMissingTypeParameterName);
+        consume(parser, TOKEN_IDENTIFIER,
+            "Expecting the name of a parameter after its type");
         param.value = parser->previous;
 
         PUSH_ARRAY(ASTParameter, s->as.opcode, param, param);
@@ -394,12 +344,13 @@ static void opcode(Parser* parser) {
             break;
         }
     }
-    consume(parser, &errOpcodeParamEnd, TokenNames[parser->current.type]);
+    consume(parser, TOKEN_RIGHT_PAREN, "Expected right paren, got %s",
+        TokenNames[parser->current.type]);
 
 
     INFO("Parsed opcode statement header");
 
-    consume(parser, &errBlockStart);
+    consume(parser, TOKEN_LEFT_BRACE, "Expected \"{\" at start of block");
 
     DEBUG("Parsing long opcode statement");
     while(!check(parser, TOKEN_EOF)) {
@@ -413,17 +364,9 @@ static void opcode(Parser* parser) {
         }
     }
 
-    consume(parser, &errBlockEnd);
+    consume(parser, TOKEN_RIGHT_BRACE, "Expected \"}\" at end of block");
 
     s->isValid = !endErrorState(parser);
-}
-
-static Error errCouldNotFindFile = {0};
-static Error errMissingIncludeFileName = {0};
-static void includeErrors() {
-    newErrPrevious(&errCouldNotFindFile, ERROR_SEMANTIC, "Could not find file \"%s\"");
-    newErrCurrent(&errMissingIncludeFileName, ERROR_SYNTAX,
-        "Expected string containing file name to include.");
 }
 
 static void include(Parser* parser) {
@@ -440,7 +383,11 @@ static void include(Parser* parser) {
             parser->ast->fileNames,
             &foundFileName);
         if(file == NULL) {
-            error(parser, &errCouldNotFindFile, parser->previous.data.string);
+            Error* err = errNew(ERROR_SEMANTIC);
+            errAddText(err, TextRed, "Could not find file \"%s\"",
+                parser->previous.data.string);
+            errAddSource(err, &parser->previous.range);
+            errEmit(err, parser);
             return;
         }
 
@@ -453,25 +400,18 @@ static void include(Parser* parser) {
         if(newParser->hadError){
             parser->hadError = true;
             for(unsigned int i = 0; i < newParser->errorCount; i++) {
-                PUSH_ARRAY(EmittedError, *parser, error, newParser->errors[i]);
+                PUSH_ARRAY(Error, *parser, error, newParser->errors[i]);
             }
         }
 
         INFO("Include parse completed");
     } else {
         INFO("Could not find input file string in source");
-        error(parser, &errMissingIncludeFileName);
+        Error* err = errNew(ERROR_SYNTAX);
+        errAddText(err, TextRed,
+            "Expected string containing file name to include.");
+        errAddSource(err, &parser->current.range);
     }
-}
-
-
-static Error errMissingBitGroupName = {0};
-static Error errBitGroupUnExpected = {0};
-static void bitgroupErrors() {
-    newErrConsume(&errMissingBitGroupName, ERROR_SYNTAX,
-        TOKEN_IDENTIFIER, "A bitgroup statement requires a name");
-    newErrPrevious(&errBitGroupUnExpected, ERROR_SYNTAX,
-        "Unexpected token of type %s while parsing bitgroup. Expecting identifier or '$'");
 }
 
 static void bitgroup(Parser* parser) {
@@ -480,16 +420,18 @@ static void bitgroup(Parser* parser) {
 
     ASTStatement* s = newStatement(parser, AST_BLOCK_BITGROUP);
 
-    consume(parser, &errMissingBitGroupName);
+    consume(parser, TOKEN_IDENTIFIER, "A bitgroup statement requires a name");
     s->as.bitGroup.name = parser->previous;
 
     ARRAY_ALLOC(ASTParameter, s->as.bitGroup, param);
-    consume(parser, &errOpcodeParamStart, TokenNames[parser->current.type]);
+    consume(parser, TOKEN_LEFT_PAREN, "Expected left paren, got %s",
+        TokenNames[parser->current.type]);
     while(match(parser, TOKEN_IDENTIFIER)) {
         ASTParameter param = {0};
         param.name = parser->previous;
 
-        consume(parser, &errMissingTypeParameterName);
+        consume(parser, TOKEN_IDENTIFIER,
+            "Expecting the name of a parameter after its type");
         param.value = parser->previous;
 
         PUSH_ARRAY(ASTParameter, s->as.bitGroup, param, param);
@@ -498,10 +440,11 @@ static void bitgroup(Parser* parser) {
             break;
         }
     }
-    consume(parser, &errOpcodeParamEnd, TokenNames[parser->current.type]);
+    consume(parser, TOKEN_RIGHT_PAREN, "Expected right paren, got %s",
+        TokenNames[parser->current.type]);
 
     ARRAY_ALLOC(ASTBitGroupIdentifier, s->as.bitGroup, segment);
-    consume(parser, &errBlockStart);
+    consume(parser, TOKEN_LEFT_BRACE, "Expected \"{\" at start of block");
     while(!match(parser, TOKEN_EOF)) {
         ASTBitGroupIdentifier id;
 
@@ -509,27 +452,28 @@ static void bitgroup(Parser* parser) {
             break;
         } else if(match(parser, TOKEN_DOLLAR)) {
             id.type = AST_BIT_GROUP_IDENTIFIER_SUBST;
-            consume(parser, &errOpcodeParamStart);
-            consume(parser, &errMissingBitGroupName);
+            consume(parser, TOKEN_LEFT_PAREN, "Expected left paren");
+            consume(parser, TOKEN_IDENTIFIER,
+                "A bitgroup statement requires a name");
             id.identifier = parser->previous;
-            consume(parser, &errOpcodeParamEnd);
+            consume(parser, TOKEN_RIGHT_PAREN, "Expected right paren");
         } else if(match(parser, TOKEN_IDENTIFIER)) {
             id.type = AST_BIT_GROUP_IDENTIFIER_LITERAL;
             id.identifier = parser->previous;
         } else {
             advance(parser);
-            error(parser, &errBitGroupUnExpected, TokenNames[parser->previous.type]);
+            Error* err = errNew(ERROR_SYNTAX);
+            errAddText(err, TextRed, "Unexpected token of type %s while "
+                "parsing bitgroup. Expecting identifier or '$'",
+                TokenNames[parser->previous.type]);
+            errAddSource(err, &parser->previous.range);
+            errEmit(err, parser);
             break;
         }
         PUSH_ARRAY(ASTBitGroupIdentifier, s->as.bitGroup, segment, id);
     }
 
     s->isValid = !endErrorState(parser);
-}
-
-static Error errExpectedBlock = {0};
-static void blockErrors() {
-    newErrPrevious(&errExpectedBlock, ERROR_SYNTAX, "Expected a block statement, got %s");
 }
 
 // dispatch the parser for a block level statement
@@ -544,19 +488,18 @@ static void block(Parser* parser) {
         case TOKEN_INCLUDE: include(parser); break;
         case TOKEN_BITGROUP: bitgroup(parser); break;
         case TOKEN_IDENTIFIER: parameter(parser); break;
-        default:
+        default: {
             INFO("Could not find valid block statement");
-            error(parser, &errExpectedBlock, TokenNames[parser->previous.type]);
+            Error* err = errNew(ERROR_SYNTAX);
+            errAddText(err, TextRed, "Expected a block statement, got %s",
+                TokenNames[parser->previous.type]);
+            errAddSource(err, &parser->previous.range);
+            errEmit(err, parser);
+        }
     }
 
     // if error occured reset parser state to known value
     if(parser->panicMode) syncronise(parser);
-}
-
-static Error errRecursiveInclude = {0};
-static void runParserErrors() {
-    newErrCurrent(&errRecursiveInclude, ERROR_SEMANTIC,
-        "Recursive include detected of file \"%s\"");
 }
 
 static bool runParser(Parser* parser) {
@@ -568,7 +511,11 @@ static bool runParser(Parser* parser) {
     DEBUG("Checking filename is valid");
     for(unsigned int i = 0; i < parser->ast->fileNameCount; i++) {
         if(parser->ast->fileNames[i] == parser->scanner->fileName) {
-            error(parser, &errRecursiveInclude, parser->scanner->fileName);
+            Error* err = errNew(ERROR_SEMANTIC);
+            errAddText(err, TextRed, "Recursive include detected of file "
+                "\"%s\"", parser->scanner->fileName);
+            errAddSource(err, &parser->current.range);
+            errEmit(err, parser);
             return false;
         }
     }
@@ -585,36 +532,8 @@ static bool runParser(Parser* parser) {
     return !parser->hadError;
 }
 
-static bool errorsInitialised;
-typedef void (*errorInitialiser)();
-static errorInitialiser errorInitialisers[] = {
-    advanceErrors,
-    microcodeLineErrors,
-    typeEnumErrors,
-    typeErrors,
-    parameterErrors,
-    headerErrors,
-    opcodeErrors,
-    includeErrors,
-    bitgroupErrors,
-    blockErrors,
-    runParserErrors
-};
-
-void InitParser() {
-    CONTEXT(INFO, "Initialising parser data");
-
-    if(!errorsInitialised) {
-        for(unsigned int i = 0; i < sizeof(errorInitialisers)/sizeof(errorInitialiser); i++) {
-            errorInitialisers[i]();
-        }
-    }
-}
-
 bool Parse(Parser* parser, Scanner* scan, AST* ast) {
     CONTEXT(INFO, "Initialising new parser");
-
-    if(!errorsInitialised)InitParser();
 
     parser->scanner = scan;
     parser->hadError = false;

--- a/src/microcode/parser.c
+++ b/src/microcode/parser.c
@@ -113,13 +113,13 @@ static BitArray parseMicrocodeBitArray(Parser* parser) {
     BitArray result;
     result.range.column = parser->current.range.column;
     result.range.line = parser->current.range.line;
-    result.range.start = parser->current.range.start;
+    result.range.tokenStart = parser->current.range.tokenStart;
     ARRAY_ALLOC(Token, result, data);
     while(match(parser, TOKEN_IDENTIFIER)) {
         Bit bit;
         bit.range.column = parser->current.range.column;
         bit.range.line = parser->current.range.line;
-        bit.range.start = parser->current.range.start;
+        bit.range.tokenStart = parser->current.range.tokenStart;
         bit.data = parser->previous;
         ARRAY_ZERO(bit, param);
         if(match(parser, TOKEN_LEFT_PAREN)) {
@@ -133,15 +133,15 @@ static BitArray parseMicrocodeBitArray(Parser* parser) {
             consume(parser, TOKEN_RIGHT_PAREN, "Expected ')', got '%s'",
                 parser->previous.data.string);
         }
-        bit.range.length = parser->previous.range.start +
-            parser->previous.range.length - bit.range.start;
+        bit.range.length = parser->previous.range.tokenStart +
+            parser->previous.range.length - bit.range.tokenStart;
         PUSH_ARRAY(Token, result, data, bit);
         if(!match(parser, TOKEN_COMMA)) {
             break;
         }
     }
-    result.range.length = parser->previous.range.start +
-        parser->previous.range.length - result.range.start;
+    result.range.length = parser->previous.range.tokenStart +
+        parser->previous.range.length - result.range.tokenStart;
     return result;
 }
 

--- a/src/microcode/parser.h
+++ b/src/microcode/parser.h
@@ -29,7 +29,7 @@ typedef struct Parser {
 
     DEFINE_ARRAY(bool, errorStack);
 
-    DEFINE_ARRAY(struct EmittedError, error);
+    DEFINE_ARRAY(struct Error*, error);
 } Parser;
 
 // initialise a new parser

--- a/src/microcode/parser.h
+++ b/src/microcode/parser.h
@@ -32,9 +32,6 @@ typedef struct Parser {
     DEFINE_ARRAY(struct Error*, error);
 } Parser;
 
-// initialise a new parser
-void InitParser();
-
 // run the parser
 bool Parse(Parser* parse, Scanner* scan, AST* ast);
 

--- a/src/microcode/scanner.c
+++ b/src/microcode/scanner.c
@@ -233,7 +233,7 @@ static Token string(Scanner* scanner, char end) {
     Token ret = makeToken(scanner, TOKEN_STRING);
     char* buf = ArenaAlloc(sizeof(char) * (ret.range.length-2+1));
     *buf = '\0';
-    strncat(buf, ret.range.start+1, ret.range.length-2);
+    strncat(buf, ret.range.tokenStart+1, ret.range.length-2);
     ret.data.string = buf;
     return ret;
 }
@@ -275,11 +275,12 @@ static MicrocodeTokenType checkKeyword(Scanner* scanner, int start, int length,
 static Token makeToken(Scanner* scanner, MicrocodeTokenType type) {
     Token token;
     token.type = type;
-    token.range.start = scanner->start;
+    token.range.tokenStart = scanner->start;
     token.range.length = (int)(scanner->current - scanner->start);
     token.range.line = scanner->line;
     token.range.column = scanner->column;
     token.range.filename = scanner->fileName;
+    token.range.sourceStart = scanner->base;
     if(type == TOKEN_IDENTIFIER) {
         token.data.string = tokenAllocName(&token);
     }
@@ -291,11 +292,12 @@ static Token makeToken(Scanner* scanner, MicrocodeTokenType type) {
 static Token errorToken(Scanner* scanner, const char* message) {
     Token token;
     token.type = TOKEN_ERROR;
-    token.range.start = scanner->start;
+    token.range.tokenStart = scanner->start;
     token.range.length = (int)(scanner->current - scanner->start);
     token.range.line = scanner->line;
     token.range.column = scanner->column;
     token.range.filename = scanner->fileName;
+    token.range.sourceStart = scanner->base;
     token.data.string = message;
 
     return token;

--- a/src/microcode/scanner.c
+++ b/src/microcode/scanner.c
@@ -279,6 +279,7 @@ static Token makeToken(Scanner* scanner, MicrocodeTokenType type) {
     token.range.length = (int)(scanner->current - scanner->start);
     token.range.line = scanner->line;
     token.range.column = scanner->column;
+    token.range.filename = scanner->fileName;
     if(type == TOKEN_IDENTIFIER) {
         token.data.string = tokenAllocName(&token);
     }
@@ -294,6 +295,7 @@ static Token errorToken(Scanner* scanner, const char* message) {
     token.range.length = (int)(scanner->current - scanner->start);
     token.range.line = scanner->line;
     token.range.column = scanner->column;
+    token.range.filename = scanner->fileName;
     token.data.string = message;
 
     return token;

--- a/src/microcode/token.c
+++ b/src/microcode/token.c
@@ -15,12 +15,12 @@ const char* TokenNames[] = {
 // simple debug print
 void TokenPrint(Token* token) {
     printf("%.4i:%.4i %.17s: %.*s", token->range.line, token->range.column,
-        TokenNames[token->type], token->range.length, token->range.start);
+        TokenNames[token->type], token->range.length, token->range.tokenStart);
 }
 
 Token createStrToken(const char* str) {
     Token t;
-    t.range.start = str;
+    t.range.tokenStart = str;
     t.range.length = strlen(str);
     t.data.string = str;
     return t;
@@ -28,7 +28,7 @@ Token createStrToken(const char* str) {
 
 Token* createStrTokenPtr(const char* str) {
     Token* t = ArenaAlloc(sizeof(Token));
-    t->range.start = str;
+    t->range.tokenStart = str;
     t->range.length = strlen(str);
     return t;
 }
@@ -37,7 +37,7 @@ Token* createUIntTokenPtr(unsigned int num) {
     Token* t = ArenaAlloc(sizeof(Token));
     char* str = ArenaAlloc(sizeof(char) * 6);
     sprintf(str, "%u", num);
-    t->range.start = str;
+    t->range.tokenStart = str;
     t->range.length = strlen(str);
     t->data.value = num;
     return t;
@@ -49,7 +49,7 @@ uint32_t tokenHash(void* value) {
     uint32_t hash = 2166126261u;
 
     for(int i = 0; i < token->range.length; i++) {
-        hash ^= token->range.start[i];
+        hash ^= token->range.tokenStart[i];
         hash *= 16777619;
     }
 
@@ -63,12 +63,12 @@ bool tokenCmp(void* a, void* b) {
     if(tokA->range.length != tokB->range.length) {
         return false;
     }
-    return strncmp(tokA->range.start, tokB->range.start, tokA->range.length) == 0;
+    return strncmp(tokA->range.tokenStart, tokB->range.tokenStart, tokA->range.length) == 0;
 }
 
 const char* tokenAllocName(Token* tok) {
     char* ret = ArenaAlloc(sizeof(char) * tok->range.length + 1);
-    strncpy(ret, tok->range.start, tok->range.length);
+    strncpy(ret, tok->range.tokenStart, tok->range.length);
     ret[tok->range.length] = '\0';
     return ret;
 }

--- a/src/microcode/token.h
+++ b/src/microcode/token.h
@@ -28,7 +28,8 @@ const char* TokenNames[FOREACH_TOKEN(ADD_TOKEN)];
 
 typedef struct SourceRange {
     const char* filename;
-    const char* start;
+    const char* tokenStart;
+    const char* sourceStart;
     int length;
     int line;
     int column;

--- a/src/microcode/token.h
+++ b/src/microcode/token.h
@@ -27,6 +27,7 @@ const char* TokenNames[FOREACH_TOKEN(ADD_TOKEN)];
 #undef ADD_TOKEN
 
 typedef struct SourceRange {
+    const char* filename;
     const char* start;
     int length;
     int line;

--- a/src/shared/memory.c
+++ b/src/shared/memory.c
@@ -2,6 +2,7 @@
 #include <string.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <stdarg.h>
 #include "shared/memory.h"
 #include "shared/log.h"
 
@@ -104,4 +105,25 @@ void* ArenaReAlloc(void* old_ptr, size_t old_size, size_t new_size) {
     void* new_ptr = ArenaAlloc(new_size);
     memcpy(new_ptr, old_ptr, old_size);
     return new_ptr;
+}
+
+char* aprintf(char* format, ...) {
+    va_list args;
+    va_start(args, format);
+    char* buf = vaprintf(format, args);
+    va_end(args);
+    return buf;
+}
+
+char* vaprintf(char* format, va_list args) {
+
+    va_list lengthArgs;
+    va_copy(lengthArgs, args);
+    size_t len = vsnprintf(NULL, 0, format, lengthArgs) + 1;
+    va_end(lengthArgs);
+
+    char* buf = ArenaAlloc(len * sizeof(char));
+    vsprintf(buf, format, args);
+
+    return buf;
 }

--- a/src/shared/memory.c
+++ b/src/shared/memory.c
@@ -106,7 +106,7 @@ void* ArenaReAlloc(void* old_ptr, size_t old_size, size_t new_size) {
     return new_ptr;
 }
 
-char* aprintf(char* format, ...) {
+char* aprintf(const char* format, ...) {
     va_list args;
     va_start(args, format);
     char* buf = vaprintf(format, args);
@@ -114,7 +114,7 @@ char* aprintf(char* format, ...) {
     return buf;
 }
 
-char* vaprintf(char* format, va_list args) {
+char* vaprintf(const char* format, va_list args) {
 
     va_list lengthArgs;
     va_copy(lengthArgs, args);

--- a/src/shared/memory.c
+++ b/src/shared/memory.c
@@ -2,7 +2,6 @@
 #include <string.h>
 #include <stdint.h>
 #include <stdlib.h>
-#include <stdarg.h>
 #include "shared/memory.h"
 #include "shared/log.h"
 

--- a/src/shared/memory.h
+++ b/src/shared/memory.h
@@ -3,6 +3,7 @@
 
 #include <stddef.h>
 #include <stdbool.h>
+#include <stdarg.h>
 
 // section of memory
 typedef struct Area {

--- a/src/shared/memory.h
+++ b/src/shared/memory.h
@@ -74,6 +74,6 @@ void* ArenaReAlloc(void* old_ptr, size_t old_size, size_t new_size);
 
 // format a string into a newly allocated buffer valid for the life of
 // the compiler - avoids storing va_list
-char* aprintf(char* format, ...);
+char* aprintf(const char* format, ...);
 
-char* vaprintf(char* format, va_list args);
+char* vaprintf(const char* format, va_list args);

--- a/src/shared/memory.h
+++ b/src/shared/memory.h
@@ -70,3 +70,9 @@ void* ArenaReAlloc(void* old_ptr, size_t old_size, size_t new_size);
     ((container).name##Count--,(container).name##s[(container).name##Count])
 
 #endif
+
+// format a string into a newly allocated buffer valid for the life of
+// the compiler - avoids storing va_list
+char* aprintf(char* format, ...);
+
+char* vaprintf(char* format, va_list args);


### PR DESCRIPTION
Only for use inside the compiler, to make development easier.
Also noticed several bugs that would have crashed the compiler which should not happen in this version as it uses the c compiler for typechecking, rather than variadac arguments and hope.